### PR TITLE
Travis CIからslackへ通知、Herokにデプロイ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,11 @@ node_js:
   - 0.10
 services:
   - mongodb
+notifications:
+  slack:
+    secure: DSlwA6dvkTeKgn8iugYoWrJRdec/TXxy6NxpIn7/jyfZGn4fzUPoLkyMhGrUEDqK0fZh/g3q+KnlzraPMknWa0vnbjsKvNAriJkIHRY7BBXdR0xc4pe5goLvImRGh4haxdvXpqbv2YpDMvYxHLiPJCX/V6cSBUsEg5hhKs3by10=
+deploy:
+  provider: heroku
+  api_key:
+    secure: Vdzv6hvityNbDRNvyIvfH1p9FWa8n9GgWcjB7kiMUTIZilUhjT247BnqGvi/IqDXIX3xK8+MwMhDW9TRBmjE0/CneHq9hii2EAN4QPHhRdKWSB477bEfl7s8k2iFOg1rLw1vOJg2dGu3wTvol5ysDeGuoFiHIirsQsMXPDFP1qA=
+  app: node-gyazz

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -17,7 +17,7 @@ module.exports = (grunt) ->
     coffeelint:
       options:
         max_line_length:
-          value: 79
+          value: 119
         indentation:
           value: 2
         newlines_after_classes:


### PR DESCRIPTION
- Travis CIからslackへの通知設定を追加
- Travisでmasterブランチのテストが通ったら http://node-gyazz.herokuapp.com/ に自動デプロイする
- coffeelintの1行の制限を80文字から120文字へ変更、80文字は正直短すぎると思う
