### PR TITLE
socketsのdebug出力名が gyazz:~~ になっていなかったので修正  #1

### DIFF
--- a/sockets/readwrite.coffee
+++ b/sockets/readwrite.coffee
@@ -2,7 +2,7 @@
 # socket.ioを利用したデータ読み書き (サーバ側)
 #
 
-debug    = require('debug')('readwrite:sockets')
+debug    = require('debug')('gyazz:sockets:readwrite')
 mongoose = require 'mongoose'
 
 Pages  = mongoose.model 'Page'


### PR DESCRIPTION
名前が`readwrite:sockets`だったので直しました。

このアプリ内のdebugの名前は`gyazz:`からはじめるようにしましょう

debugはワイルドカードで指定して出力を変えるためにあるので、

```
% DEBUG=gyazz* npm start
```

こうやって起動してgyazzから始まるdebugが全部見れるようにしたりします
