### PR TITLE
同じページを見ているクライアント毎にroomで分けて、無駄に全員にbroadcastしないようにした

### DIFF
--- a/public/javascripts/gyazz_edit.coffee
+++ b/public/javascripts/gyazz_edit.coffee
@@ -1,4 +1,4 @@
-socket = io()
+socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{wiki}&title=#{title}"
 gt = new GyazzTag
 
 $ ->

--- a/public/javascripts/gyazz_socket.coffee
+++ b/public/javascripts/gyazz_socket.coffee
@@ -1,7 +1,7 @@
 class GyazzSocket
   
   init: (gb, gd, gt) ->
-    @socket = io()
+    @socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{wiki}&title=#{title}"
     @gb = gb
     @gd = gd
     @gt = gt

--- a/views/edit.jade
+++ b/views/edit.jade
@@ -6,21 +6,20 @@ html
     link(rel="stylesheet",href="/stylesheets/gyazz.css",type="text/css")
     link(rel="shortcut icon",href="/favicon.ico")
     script(src="/javascripts/jquery.js")
-    script(src='/javascripts/utf.js')
-    script(src='/javascripts/md5.js')
-    script(src='/javascripts/underscore.js')
-
-    script(src='/socket.io/socket.io.js')
-
-    script(src='/javascripts/gyazz_tag.js')
-    script(src='/javascripts/gyazz_edit.js')
-
+    script(src="/socket.io/socket.io.js")
     script.
       var wiki = "#{wiki}"; // escape_jsvar
       var title = "#{title}"; // escape_jsvar
       var do_auth = false;
       var writable = true;
       var version = "#{version}";
+
+    script(src='/javascripts/utf.js')
+    script(src='/javascripts/md5.js')
+    script(src='/javascripts/underscore.js')
+
+    script(src='/javascripts/gyazz_tag.js')
+    script(src='/javascripts/gyazz_edit.js')
 
   body
     - var writable = true

--- a/views/page.jade
+++ b/views/page.jade
@@ -10,6 +10,12 @@ html
     link(rel="alternate",type="application/rss+xml",title="#{title} RSS Feed",href="#{wiki}/rss.xml")
     meta(name="robots",content="page.wiki[searchable] ? index,follow : noindex,nofollow")
 
+    script.
+      var wiki = "#{wiki}"; // escape_jsvar
+      var title = "#{title}"; // escape_jsvar
+      var do_auth = false;
+      var writable = true;
+
     script(src='/javascripts/pbsearch.js')
     script(src='/javascripts/pbdict.js')
     script(src='/javascripts/utf.js')
@@ -21,20 +27,6 @@ html
 
     script(src='/socket.io/socket.io.js')
 
-    script(src='/javascripts/coffee-script.js')
-    // この下ので動いてほしいのだがうまくいかない 2014/07/22 19:20:36
-    //script(type='text/coffeescript', src='/javascripts/gyazz_lib.coffee')
-    //script(type='text/coffeescript', src='/javascripts/gyazz_tag.coffee')
-    //script(type='text/coffeescript', src='/javascripts/gyazz_buffer.coffee')
-    //script(type='text/coffeescript', src='/javascripts/gyazz_related.coffee')
-    //script(type='text/coffeescript', src='/javascripts/gyazz_notification.coffee')
-    //script(type='text/coffeescript', src='/javascripts/gyazz_upload.coffee')
-    //script(type='text/coffeescript', src='/javascripts/gyazz_display.coffee')
-    //script(type='text/coffeescript', src='/javascripts/gyazz_socket.coffee')
-    //script(type='text/coffeescript', src='/javascripts/gyazz_location.coffee')
-    //script(type='text/coffeescript', src='/javascripts/gyazz.coffee')
-
-    // こちらは動く
     script(src='/javascripts/gyazz_lib.js')
     script(src='/javascripts/gyazz_tag.js')
     script(src='/javascripts/gyazz_buffer.js')
@@ -46,11 +38,6 @@ html
     script(src='/javascripts/gyazz_location.js')
     script(src='/javascripts/gyazz.js')
 
-    script.
-      var wiki = "#{wiki}"; // escape_jsvar
-      var title = "#{title}"; // escape_jsvar
-      var do_auth = false;
-      var writable = true;
   body
     - var writable = true;
     div.title


### PR DESCRIPTION
#63 を実装しました
- socket.ioの接続時のhanshake queryで部屋名とwiki名をサーバーに送信し、room名に使う
- editページでもsocket.ioのroomを使う
