### PR TITLE
不正なページ名・WiKi名をチェック

### DIFF
--- a/models/access.coffee
+++ b/models/access.coffee
@@ -8,8 +8,20 @@ mongoose = require 'mongoose'
 module.exports = (app) ->
 
   accessSchema = new mongoose.Schema
-    wiki: String
-    title: String
+    wiki:
+      type: String
+      validate: [
+        (v) ->
+          return mongoose.model('Page').isValidName(v)
+        'Invalid WiKi name'
+      ]
+    title:
+      type: String
+      validate: [
+        (v) ->
+          return mongoose.model('Page').isValidName(v)
+        'Invalid WiKi name'
+      ]
     timestamp: Date
 
   #accessSchema.statics.access = (wiki, title, callback) ->

--- a/models/attr.coffee
+++ b/models/attr.coffee
@@ -9,8 +9,20 @@ mongoose = require 'mongoose'
 module.exports = (app) ->
 
   attrSchema = new mongoose.Schema
-    wiki: String
-    title: String
+    wiki:
+      type: String
+      validate: [
+        (v) ->
+          return mongoose.model('Page').isValidName(v)
+        'Invalid WiKi name'
+      ]
+    title:
+      type: String
+      validate: [
+        (v) ->
+          return mongoose.model('Page').isValidName(v)
+        'Invalid WiKi name'
+      ]
     attr:
       repimage: String
 

--- a/models/line.coffee
+++ b/models/line.coffee
@@ -9,8 +9,20 @@ mongoose = require 'mongoose'
 module.exports = (app) ->
 
   lineSchema = new mongoose.Schema
-    wiki: String
-    title: String
+    wiki:
+      type: String
+      validate: [
+        (v) ->
+          return mongoose.model('Page').isValidName(v)
+        'Invalid WiKi name'
+      ]
+    title:
+      type: String
+      validate: [
+        (v) ->
+          return mongoose.model('Page').isValidName(v)
+        'Invalid WiKi name'
+      ]
     line: String
     timestamp: Date
 

--- a/models/pair.coffee
+++ b/models/pair.coffee
@@ -9,9 +9,27 @@ mongoose = require 'mongoose'
 module.exports = (app) ->
 
   pairSchema = new mongoose.Schema
-    wiki: String
-    title1: String
-    title2: String
+    wiki:
+      type: String
+      validate: [
+        (v) ->
+          return mongoose.model('Page').isValidName(v)
+        'Invalid WiKi name'
+      ]
+    title1:
+      type: String
+      validate: [
+        (v) ->
+          return mongoose.model('Page').isValidName(v)
+        'Invalid WiKi name'
+      ]
+    title2:
+      type: String
+      validate: [
+        (v) ->
+          return mongoose.model('Page').isValidName(v)
+        'Invalid WiKi name'
+      ]
 
   # pageに関連するページの配列を得る
   pairSchema.statics.related = (wiki, title, callback) ->

--- a/sockets/readwrite.coffee
+++ b/sockets/readwrite.coffee
@@ -29,7 +29,7 @@ module.exports = (app) ->
       return if _busy && ! req.opts.force
       _busy = true
       debug "readwrite.coffee: #{req.wiki}::#{req.title} read request from client"
-      Pages.json req.wiki, req.title, req.opts, (err, page) ->
+      Pages.findByName req.wiki, req.title, req.opts, (err, page) ->
         if err
           debug "Pages error"
           return
@@ -72,7 +72,8 @@ module.exports = (app) ->
         page.timestamp = curtime
         page.save (err) ->
           if err
-            debug "Write error"
+            debug "Write error: #{err}"
+            return
 
           socket.emit 'writesuccess' # クライアントだけに返す
           
@@ -95,6 +96,7 @@ module.exports = (app) ->
             .exec (err, results) ->
               if err
                 debug "line read error"
+                return
               if results.length == 0
                 line = new Lines
                 line.wiki      = wiki


### PR DESCRIPTION
#102 の実装をしました

動作確認はローカルでのみしています
## 主な修正点
- ページ名・WiKi名が不正な場合、正しいURLにリダイレクト
- model全てのwiki,titleプロパティにvalidationを設定し、問題あるデータを保存できないようにした
- Page modelのstaticメソッドとしてisValidName(str), toValidName(str)を実装
- Page.json関数をPage.findByNameに変更、名前がおかしかった為
- Page.json関数で古いデータが無いページから過去のデータを取得しようとした時に、callbackが返らないバグを修正
- ページデータが読み込めない時にstatus:500でエラーを返す
- ページアクセスの記録完了を待たずにページデータを取得して返す（平行化）
- エラーがあっても処理が続行されてたり、値を返さない箇所があったので修正した
### 変なページ名にアクセスするとリダイレクトします

![](http://gyazo.com/46614eec11b7326f43915f254594b63a.gif)
