### PR TITLE
編集時に空行が削除されるバグを修正

### DIFF
--- a/sockets/readwrite.coffee
+++ b/sockets/readwrite.coffee
@@ -80,7 +80,7 @@ module.exports = (app) ->
           data = text.split(/\n/) or []
           Lines.timestamps wiki, title, data, (err, timestamps) ->
             debug "readwrite.coffee: send data back to client"
-            io.sockets.to(room).emit 'pagedata', { # 同じページを見ている相手に送信
+            socket.broadcast.to(room).emit 'pagedata', { # 同じページを見ている自分以外の相手に送信
               wiki:        wiki
               title:       title
               date:        curtime


### PR DESCRIPTION
#99 修正しました

自分以外の同じページを見ている相手にだけページデータを送信するようにしました

ブラウザ2つ開いて、変更が互いに通知されて表示更新されるのも確認しました
