### PR TITLE
まだAttrが無いページのrepimageを更新しようとして死ぬバグを修正

### DIFF
--- a/controllers/main.coffee
+++ b/controllers/main.coffee
@@ -59,7 +59,7 @@ module.exports = (app) ->
         else
           res.redirect "http://gyazo.com/#{image}.png"
       else
-        res.send 404, "image not found"
+        res.status(404).send "image not found"
 
   #  ページ内容取得 (apiとしてだけ)用意
   app.get /^\/([^\/]+)\/(.*)\/json$/, (req, res) ->

--- a/models/attr.coffee
+++ b/models/attr.coffee
@@ -28,6 +28,7 @@ module.exports = (app) ->
         type: String
         validate: [
           (v) ->
+            return true if v is null
             return /^https?:\/\/.+/.test v
           'Invalid Image URL'
         ]

--- a/models/page.coffee
+++ b/models/page.coffee
@@ -50,12 +50,15 @@ module.exports = (app) ->
         "#{m[1]}.#{m[2]}"
       else
         null
-    mongoose.model('Attr').findOne
+    Attr = mongoose.model('Attr')
+    Attr.findOne
       wiki: page.wiki
       title: page.title
     .exec (err, attr) =>
       if err
         return
+      unless attr
+        attr = new Attr {wiki: page.wiki, title: page.title}
       attr.attr.repimage = repimage
       attr.save (err) ->
         debug err if err


### PR DESCRIPTION
プルリク #112 で入ったバグを修正しました
- まだAttrが無いページのrepimageを更新しようとして死ぬバグを修正
- repimageのvalidatorを修正、URLもしくはnullを保存できるようにした  #109
- express3以前のAPI res.send(status, body) を使わない
