### PR TITLE
遅延書き込みとキャッシュによりページ書き込み頻度を下げた

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ Node, Express, MongoDBで再実装しました。
 [![Build Status](https://travis-ci.org/masuilab/Gyazz.svg?branch=master)](https://travis-ci.org/masuilab/Gyazz)
 
 
+# 必要環境
+
+- Node.js 0.10.x
+- MongoDB 2.x
+- memcached
+
+
 # Install Dependencies
+
+
+    % brew install mongodb memcached
 
     % npm i
 
@@ -53,6 +63,9 @@ gruntでファイル更新をwatchし、継続的にtestを実行しつつcoffee
     # or
     % heroku addons:add mongohq
 
+### enable memcached plug-in
+
+    % heroku addons:add memcachier
 
 ### logs
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grunt-notify": "*",
     "grunt-simple-mocha": "*",
     "jade": "*",
+    "memjs": "^0.8.5",
     "mocha": "*",
     "mongoose": "3.x",
     "morgan": "^1.0.0",

--- a/public/javascripts/gyazz_edit.coffee
+++ b/public/javascripts/gyazz_edit.coffee
@@ -5,26 +5,23 @@ $ ->
   opts = {version: version}
   
   socket.on 'pagedata', (res) =>
-    if res.wiki == wiki && res.title == title
-      $('#contents').val res.data.join("\n")
+    $('#contents').val res.data.join("\n")
 
-  socket.emit 'read',
-    wiki:  wiki
-    title: title
-    opts:  opts
+  socket.on 'connect', ->
+    socket.emit 'read',
+      opts:  opts
 
-$(document).keyup (event) ->
-  clearTimeout timeout if timeout?
-  timeout = setTimeout ->
-    contents = $('#contents').val()
-    datastr = contents.replace(/\n+$/,'')+"\n"
-    keywords = _.flatten contents.split(/\n/).map (line) =>
-      gt.keywords(line, wiki, title, 0)
-    socket.emit 'write',
-      wiki:     wiki
-      title:    title
-      data:     datastr
-      keywords: keywords
-    $("#contents").css('background-color','#ffffff')
-  , 3000
-  $("#contents").css('background-color','#e0e0e0')
+  socket.once 'pagedata', ->
+    $(document).keyup (event) ->
+      clearTimeout timeout if timeout?
+      timeout = setTimeout ->
+        contents = $('#contents').val()
+        datastr = contents.replace(/\n+$/,'')+"\n"
+        keywords = _.flatten contents.split(/\n/).map (line) =>
+          gt.keywords(line, wiki, title, 0)
+        socket.emit 'write',
+          data:     datastr
+          keywords: keywords
+        $("#contents").css('background-color','#ffffff')
+      , 3000
+      $("#contents").css('background-color','#e0e0e0')

--- a/public/javascripts/gyazz_socket.coffee
+++ b/public/javascripts/gyazz_socket.coffee
@@ -7,24 +7,20 @@ class GyazzSocket
     @gt = gt
 
     @socket.on 'pagedata', (res) =>
-      # alert "pagedata received... data = #{res.data}"
-      if res.wiki == wiki && res.title == title
-        _data_old =   res['data'].concat()
-        @gb.data    = res.data.concat()
-        @gb.datestr = res.date
-        @gb.timestamps = res.timestamps
-        @gb.refresh()
+      _data_old =   res['data'].concat()
+      @gb.data    = res.data.concat()
+      @gb.datestr = res.date
+      @gb.timestamps = res.timestamps or []
+      @gb.refresh()
         
     @socket.on 'writesuccess', (res) =>
       notifyBox.hide()
 
-  getdata: (opts=null, callback=null) =>
-    opts = {} if opts == null || typeof opts != 'object'
+  getdata: (opts = {}, callback = ->) =>
+    opts = {} if typeof opts isnt 'object'
     if typeof opts.version != 'number' || 0 > opts.version
       opts.version = 0
     @socket.emit 'read',
-      wiki:  wiki
-      title: title
       opts:  opts
 
   _oldstr = ""
@@ -37,8 +33,6 @@ class GyazzSocket
     keywords = _.flatten data.map (line) =>
       @gt.keywords(line, wiki, title, 0)
     @socket.emit 'write',
-      wiki:     wiki
-      title:    title
       data:     datastr
       keywords: keywords
   

--- a/sockets/readwrite.coffee
+++ b/sockets/readwrite.coffee
@@ -4,105 +4,75 @@
 
 debug    = require('debug')('gyazz:sockets:readwrite')
 mongoose = require 'mongoose'
+async    = require 'async'
 
 Page  = mongoose.model 'Page'
 Line  = mongoose.model 'Line'
 Pair  = mongoose.model 'Pair'
 
+write_timeout_ids = {}
+
 module.exports = (app) ->
   io = app.get 'socket.io'
-
-  writetime = {}
-
-  _busy = false
 
   io.on 'connection', (socket) ->
     debug "socket.io connected from client--------"
 
+    wiki  = socket.handshake.query.wiki
+    title = socket.handshake.query.title
+    unless wiki and title
+      socket.disconnect()
+      return
+
     ## 同じページを見ているクライアント毎にroomで分ける
-    room = "#{socket.handshake.query.wiki}/#{socket.handshake.query.title}"
+    room = "#{wiki}/#{title}"
     socket.join room
     socket.once 'disconnect', ->
       socket.leave room
 
     socket.on 'read', (req) ->
-      return if _busy && ! req.opts.force
-      _busy = true
-      debug "readwrite.coffee: #{req.wiki}::#{req.title} read request from client"
-      Page.findByName req.wiki, req.title, req.opts, (err, page) ->
+      debug "readwrite.coffee: #{wiki}::#{title} read request from client"
+      Page.findByName wiki, title, req.opts, (err, page) ->
+        debug "findByName callback"
         if err
           debug "Page error"
           return
-        data =  page?.text.split(/\n/) or []
+        data = page?.text.split(/\n/) or []
         # 行ごとの古さを計算する
-        Line.timestamps req.wiki, req.title, data, (err, timestamps) ->
+        Line.timestamps wiki, title, data, (err, timestamps) ->
           debug "readwrite.coffee: send data back to client"
-          # io.sockets.emit 'pagedata', { # 自分を含むあらゆる接続先にデータ送信
           socket.emit 'pagedata', { # 自分だけに返信
-            wiki:        req.wiki
-            title:       req.title
             date:        page?.timestamp
             timestamps:  timestamps
             data:        data
           }
-          _busy = false
 
     # write処理時にリンク情報を更新する必要あり
     # データはgyazz_related.coffeeで使っている
     # pair.coffee でDBから取得している
     #
     socket.on 'write', (req) ->
-      debug "readwrite.coffee: #{req.wiki}::#{req.title} write request from client"
-      wiki     = req.wiki
-      title    = req.title
+      debug "readwrite.coffee: #{wiki}::#{title} write request from client"
       text     = req.data
       keywords = req.keywords
-      curtime = new Date
-      lasttime = writetime["#{wiki}::#{title}"]
-      # console.log "Write! data=#{text}"
-      if !lasttime || curtime > lasttime
-        writetime["#{wiki}::#{title}"] = curtime
 
+      # 同じページを見ている自分以外の相手に送信
+      socket.broadcast.to(room).emit 'pagedata', {
+        date: Date.now()
+        data: text?.split(/[\r\n]+/) or []
+      }
+
+      Page.saveNewPage wiki, title, text, (err) ->
+        if err
+          debug "save error: #{err}"
+          return
+        debug "#{wiki}::#{title} page saved"
+        socket.emit 'writesuccess' # 書き込んできたクライアントに完了通知
         Pair.refresh wiki, title, keywords # リンク情報登録
-        
-        page = new Page
-        page.wiki      = wiki
-        page.title     = title
-        page.text      = text
-        page.timestamp = curtime
-        page.save (err) ->
-          if err
-            debug "Write error: #{err}"
-            return
 
-          socket.emit 'writesuccess' # クライアントだけに返す
-          
-          data = text.split(/\n/) or []
-          Line.timestamps wiki, title, data, (err, timestamps) ->
-            debug "readwrite.coffee: send data back to client"
-            socket.broadcast.to(room).emit 'pagedata', { # 同じページを見ている自分以外の相手に送信
-              wiki:        wiki
-              title:       title
-              date:        curtime
-              timestamps:  timestamps
-              data:        data
-            }
-            
-          text.split(/\n/).forEach (linetext) -> # 新しい行ならば生成時刻を記録する
-            Line.find
-              wiki:  wiki
-              title: title
-              line:  linetext
-            .exec (err, results) ->
-              if err
-                debug "line read error"
-                return
-              if results.length == 0
-                line = new Line
-                line.wiki      = wiki
-                line.title     = title
-                line.line      = linetext
-                line.timestamp = curtime
-                line.save (err) ->
-                  if err
-                    debug "line write error"
+        # 行の生成時刻を記録する
+        async.eachSeries text.split(/[\r\n]+/), (line, next) ->
+          Line.saveIfNewLine wiki, title, line, (err) ->
+            next()
+        , (errs) ->
+          debug "line timestamps saved"


### PR DESCRIPTION
#62 page collectionに書き込みすぎ と、 #122 のバグを解消しました

キャッシュにはmemcached+memjs npmを使っています
## 変更内容
- socket.io接続時のhandshake queryで指定したページしか読み書きできないようにした  #62 
- 全行編集画面のバグを修正  #122
  - socket.ioが接続するのを待ってからreadをリクエストする
  - 全行編集画面にて、一度ページデータを受信するまでサーバーにデータ書き込みを行わない
- Line.timestamp関数がきちんとエラーを返すように修正
- Line modelにsaveIfNewLine関数を追加  #62
  - 新しいLineのtimestampを保存する処理
  - mongoに同時に大量のリクエストを送らないようにasync.eachSeriesで順次処理するようにした
- ページデータの遅延書き込みを実装、一旦キャッシュに保存して20秒後にmongodbに保存する  #62
  - memcachedを使うためにmemjs npmをインストールした
  - Page#findByName関数をキャッシュ有効にした
  - 遅延書き込み機能を持ったPage#saveNewPage関数を実装
- READMEにmemcachedを使う事を追記  #62
