### PR TITLE
ページ新規作成時にほぼ同じ名前のページがあればリダイレクトする

### DIFF
--- a/controllers/main.coffee
+++ b/controllers/main.coffee
@@ -84,10 +84,15 @@ module.exports = (app) ->
         debug "Access write error"
 
     # ページデータを読み込んでrawdataとする
-    Page.findByName wiki, title, {}, (err, page) ->
+    title_regexp =
+      new RegExp "^#{title.replace(/\s/g,'').split('').join(' ?')}$", 'i'
+    Page.findByName wiki, title_regexp, {}, (err, page) ->
       if err
         debug "Page error: #{err}"
         return res.status(500).end err
+      if page? and title isnt page?.title and !page?.isEmpty()
+        res.redirect "/#{page.wiki}/#{page.title}"
+        return
       rawdata =  page?.text or ""
       return res.render 'page',
         title:   title


### PR DESCRIPTION
#140 を実装しました。okならmergeしてください
## 変更内容
- ページ新規作成時にほぼ同じ名前のページがあればリダイレクトする
- リダイレクト先のpage内容が空の場合、リダイレクトしない
- ページ内容を削除した場合のみ、pageデータ書き込みのでバウンシングを無くしすぐに削除を行う
  - ページ名を微妙に変える時に必要
## 挙動

こういう挙動で合ってますか？
### スペース無しからスペースありの正しいページへリダイレクト

![](http://gyazo.com/72774b7e5a831a654d6a3c0e0847a0d0.gif)
### スペースありからスペースなしの正しいページへリダイレクト

![](http://gyazo.com/348510128d3caa7735c9e2d1603bb29b.gif)

ページ内容削除してから新ページに内容移動するのもできます
