### PR TITLE
jsonファイルを全てgrunt-jsonlintでチェック

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -5,16 +5,25 @@ module.exports = (grunt) ->
   require 'coffee-errors'
 
   grunt.loadNpmTasks 'grunt-contrib-watch'
+  grunt.loadNpmTasks 'grunt-jsonlint'
   grunt.loadNpmTasks 'grunt-coffeelint'
   grunt.loadNpmTasks 'grunt-simple-mocha'
   grunt.loadNpmTasks 'grunt-notify'
   grunt.loadNpmTasks 'grunt-contrib-coffee'
 
-  grunt.registerTask 'test',    [ 'coffeelint', 'simplemocha' ]
+  grunt.registerTask 'test',    [ 'jsonlint', 'coffeelint', 'simplemocha' ]
   grunt.registerTask 'default', [ 'test', 'build', 'watch' ]
   grunt.registerTask 'build',   [ 'coffee' ]
 
   grunt.initConfig
+
+    jsonlint:
+      config:
+        src: [
+          '**/*.json'
+          '!node_modules/**'
+          '!tmp/**'
+        ]
 
     coffeelint:
       options:
@@ -29,13 +38,12 @@ module.exports = (grunt) ->
         no_unnecessary_fat_arrows:
           level: 'ignore'
       dist:
-        files: [
-          { expand: yes, cwd: './', src: [ '*.coffee' ] }
-          { expand: yes, cwd: 'models/', src: [ '**/*.coffee' ] }
-          { expand: yes, cwd: 'controllers/', src: [ '**/*.coffee' ] }
-          { expand: yes, cwd: 'sockets/', src: [ '**/*.coffee' ] }
-          { expand: yes, cwd: 'public/', src: [ '**/*.coffee' ] }
-        ]
+        files:
+          src: [
+            '**/*.coffee'
+            '!node_modules/**'
+            '!tmp/**'
+          ]
 
     simplemocha:
       options:
@@ -64,12 +72,9 @@ module.exports = (grunt) ->
         interrupt: yes
       dist:
         files: [
-          '*.coffee'
-          'models/**/*.coffee'
-          'controllers/**/*.coffee'
-          'sockets/**/*.coffee'
-          'views/**/*.jade'
-          'public/**/*.coffee'
-          'tests/**/*.coffee'
+          '**/*.{coffee,js,jade}'
+          '!node_modules/**'
+          '!tmp/**'
+          '!public/**/*.js'
         ]
         tasks: [ 'test', 'build' ]

--- a/lib/png.coffee
+++ b/lib/png.coffee
@@ -13,7 +13,7 @@
 #  http://nodejs.org/api/buffer.html
 #
 # もしかして: npmに既存だったりして?
-# 
+#
 # こういうのがあった (2014/07/14 15:49:14)
 # https://www.npmjs.org/package/node-png
 #

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-coffeelint": "*",
     "grunt-contrib-coffee": "*",
     "grunt-contrib-watch": "*",
+    "grunt-jsonlint": "*",
     "grunt-notify": "*",
     "grunt-simple-mocha": "*",
     "jade": "*",


### PR DESCRIPTION
#157 を実装しました
- jsonファイルを全てgrunt-jsonlintでチェック
- gruntのwatch pathの書き方をリファクタリング
- png.coffeeをcoffee lint passするように修正
