### PR TITLE
関連ページアイコン画像が溢れ出ないようにcss修正

### DIFF
--- a/public/stylesheets/gyazz.css
+++ b/public/stylesheets/gyazz.css
@@ -451,3 +451,8 @@ div.icon {
   word-wrap:break-word;
   */
 }
+
+div.icon img {
+  max-height: 100%;
+  max-width: 100%;
+}


### PR DESCRIPTION
#153 なおしました

![image](https://cloud.githubusercontent.com/assets/34204/3886341/b69426d2-21d7-11e4-9a77-4d4460b419b3.png)
