### PR TITLE
テキストエリア編集で、無駄にデータを送信しないようにした

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -12,7 +12,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-notify'
   grunt.loadNpmTasks 'grunt-contrib-coffee'
 
-  grunt.registerTask 'test',    [
+  grunt.registerTask 'test', [
     'coffeelint'
     'simplemocha'
     'jsonlint'


### PR DESCRIPTION
#114 やりました
- テキスト内容が変わった時のみ送信
- 送信を3秒待ち、激しい編集が終わるまで待つ
- カーソル移動は無視する

![screen shot](http://gyazo.com/c340217174d9d5052358acfa13d8108d.gif)

テストはcss lint以外通っています
