### PR TITLE
ページ下の関連ページアイコンのcssを修正

### DIFF
--- a/public/stylesheets/gyazz.css
+++ b/public/stylesheets/gyazz.css
@@ -445,14 +445,6 @@ div.listedit8:before {
   background-color:#ddd;
 }
 
-.icontext {
-  font-size: 9pt;
-  margin: 3px;
-  color:white;
-  overflow:hidden;
-  word-wrap:break-word
-}
-
 div.icon {
   height: 64px;
   width:  64px;
@@ -471,22 +463,23 @@ div.icon img {
   max-width: 100%;
 }
 
-/* .icontext.overimage { */
 .icontext {
-  font-size: 8pt;
-  height: 58px;
-  width:  58px;
-  margin: 0;
-  padding: 0;
-  background-color: rgb(0, 0, 0);
-  background-color: rgba(0, 0, 0, 0.5);
+  font-size:9pt;
+  color:    white;
+  height:   58px;
+  width:    58px;
+  margin:   3px;
+  padding:  0;
+  overflow: hidden;
+  word-wrap:break-word
 }
+
 .overimage {
-  font-size: 8pt;
-  height: 58px;
-  width:  58px;
-  margin: 0;
-  padding: 0;
+  font-size:8pt;
+  height:   58px;
+  width:    58px;
+  margin:   0;
+  padding:  0;
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
#170 修正しました
- repimageなしの時はテキストに背景色を付けない
- chromeとfirefoxで確認しました

![image](https://cloud.githubusercontent.com/assets/34204/3994479/bf3c8a8c-291a-11e4-945e-039353a34943.png)
