### PR TITLE
Grunt watchでcssとjsonがwatchされていなかったのを修正

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -85,7 +85,7 @@ module.exports = (grunt) ->
         interrupt: yes
       dist:
         files: [
-          '**/*.{coffee,js,jade}'
+          '**/*.{coffee,js,jade,json,css}'
           '!node_modules/**'
           '!tmp/**'
           '!public/**/*.js'


### PR DESCRIPTION
gruntのwatchがcssとjsonファイルを見ていなかったので、監視するようにしました
