### PR TITLE
htmlとbodyの高さをウィンドウの高さと同じにした

### DIFF
--- a/public/stylesheets/gyazz.css
+++ b/public/stylesheets/gyazz.css
@@ -1,6 +1,11 @@
+html {
+  height: 100%;
+}
+
 body {
   background-color: #ffeeee;
   font-family: "Lucida Grande", "Lucida", "Lucida Sans", "Tahoma", Verdana, Arial, sans-serif;
+  height: 100%;
 }
 
 div.title {


### PR DESCRIPTION
#183

![screen shot 2014-09-04 at 19 57 35](https://cloud.githubusercontent.com/assets/1883953/4148269/0a0148e2-3423-11e4-95a8-56c59c7de7d2.png)
bodyの高さがデフォルトのautoでここまでしかなかったので、

![screen shot 2014-09-04 at 19 59 46](https://cloud.githubusercontent.com/assets/1883953/4148281/26585b52-3423-11e4-8eb8-e50b234d8242.png)
htmlとbodyのheightを100%にしてあげた
