### PR TITLE
ページ名に+や*などの正規表現予約語が入っている場合にエラーが起きるバグを修正

### DIFF
--- a/controllers/main.coffee
+++ b/controllers/main.coffee
@@ -84,8 +84,10 @@ module.exports = (app) ->
         debug "Access write error"
 
     # ページデータを読み込んでrawdataとする
+    escape_regexp_token = (str) ->
+      return str.replace /[\\\+\*\.\[\]\{\}\(\)\^\|]/g, (c) -> "\\#{c}"
     title_regexp =
-      new RegExp "^#{title.replace(/\s/g,'').split('').join(' ?')}$", 'i'
+      new RegExp "^#{title.replace(/\s/g,'').split('').join(' ?').escape_regexp_token}$", 'i'
     Page.findByName wiki, title_regexp, {}, (err, page) ->
       if err
         debug "Page error: #{err}"


### PR DESCRIPTION
#137 の実装時に入ったバグを修正しました

ページ名に + や \* や ( や [ などの正規表現で使う文字が入っている場合にレスポンスを返せませんでした
