### PR TITLE
ブラウザJSにwiki名/ページ名が正しく渡らないbugを修正

### DIFF
--- a/public/javascripts/gyazz_edit.coffee
+++ b/public/javascripts/gyazz_edit.coffee
@@ -1,4 +1,4 @@
-socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{wiki}&title=#{title}"
+socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{escape wiki}&title=#{escape title}"
 gt = new GyazzTag
 
 getData = ->

--- a/public/javascripts/gyazz_socket.coffee
+++ b/public/javascripts/gyazz_socket.coffee
@@ -1,7 +1,7 @@
 class GyazzSocket
-  
+
   init: (gb, gd, gt) ->
-    @socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{wiki}&title=#{title}"
+    @socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{escape wiki}&title=#{escape title}"
     @gb = gb
     @gd = gd
     @gt = gt
@@ -12,7 +12,7 @@ class GyazzSocket
       @gb.datestr = res.date
       @gb.timestamps = res.timestamps or []
       @gb.refresh()
-        
+
     @socket.on 'after write', (err) =>
       if err
         notifyBox.print(err).show(3000)
@@ -38,5 +38,5 @@ class GyazzSocket
     @socket.emit 'write',
       data:     datastr
       keywords: keywords
-  
+
 window.GyazzSocket = GyazzSocket

--- a/sockets/readwrite.coffee
+++ b/sockets/readwrite.coffee
@@ -16,10 +16,11 @@ module.exports = (app) ->
   io = app.get 'socket.io'
 
   io.on 'connection', (socket) ->
-    debug "socket.io connected from client--------"
+    debug "socket.io connected from client"
 
-    wiki  = socket.handshake.query.wiki
-    title = socket.handshake.query.title
+    wiki  = unescape socket.handshake.query.wiki
+    title = unescape socket.handshake.query.title
+    console.log title
     unless wiki and title
       socket.disconnect()
       return

--- a/views/edit.jade
+++ b/views/edit.jade
@@ -8,8 +8,8 @@ html
     script(src="/javascripts/jquery.js")
     script(src="/socket.io/socket.io.js")
     script.
-      var wiki = "#{wiki}"; // escape_jsvar
-      var title = "#{title}"; // escape_jsvar
+      var wiki = unescape("!{escape(wiki)}");
+      var title = unescape("!{title}");
       var do_auth = false;
       var writable = true;
       var version = "#{version}";
@@ -28,7 +28,6 @@ html
       span.wordtitle
         img#historyimage(src="/#{wiki}/#{title}/modify.png",height=18,width=80)
         | &nbsp;
-        // sanitize必要!!!
         if writable
           a#title(href="/#{wiki}/#{title}") #{title}
         else

--- a/views/page.jade
+++ b/views/page.jade
@@ -19,8 +19,8 @@ html
     meta(name="twitter:description", value=tw_desc)
 
     script.
-      var wiki = "#{wiki}"; // escape_jsvar
-      var title = "#{title}"; // escape_jsvar
+      var wiki = unescape("!{escape(wiki)}"); // escape_jsvar
+      var title = unescape("!{escape(title)}"); // escape_jsvar
       var do_auth = false;
       var writable = true;
 
@@ -30,7 +30,6 @@ html
       span.wordtitle
         img#historyimage(src="/#{wiki}/#{title}/modify.png",height=18,width=80)
         | &nbsp;
-        // sanitize必要!!!
         if writable
           a#title(href="/#{wiki}/#{title}/__edit") #{title}
         else


### PR DESCRIPTION
#196 修正しました
- サーバーの変数はjadeでescapeしてからブラウザjsでunescape
- ブラウザJSの変数はescapeしてからsocket.ioのhandshake queryに渡し、サーバー側でunescape
