### PR TITLE
ブラウザJSからsocket.ioのhandshake queryに正しくwiki名/ページ名を渡す

### DIFF
--- a/public/javascripts/gyazz_edit.coffee
+++ b/public/javascripts/gyazz_edit.coffee
@@ -1,4 +1,4 @@
-socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{escape wiki}&title=#{escape title}"
+socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{encodeURI wiki}&title=#{encodeURI title}"
 gt = new GyazzTag
 
 getData = ->

--- a/public/javascripts/gyazz_socket.coffee
+++ b/public/javascripts/gyazz_socket.coffee
@@ -1,7 +1,7 @@
 class GyazzSocket
 
   init: (gb, gd, gt) ->
-    @socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{escape wiki}&title=#{escape title}"
+    @socket = io.connect "#{location.protocol}//#{location.hostname}?wiki=#{encodeURI wiki}&title=#{encodeURI title}"
     @gb = gb
     @gd = gd
     @gt = gt

--- a/sockets/readwrite.coffee
+++ b/sockets/readwrite.coffee
@@ -18,9 +18,8 @@ module.exports = (app) ->
   io.on 'connection', (socket) ->
     debug "socket.io connected from client"
 
-    wiki  = unescape socket.handshake.query.wiki
-    title = unescape socket.handshake.query.title
-    console.log title
+    wiki  = decodeURI socket.handshake.query.wiki
+    title = decodeURI socket.handshake.query.title
     unless wiki and title
       socket.disconnect()
       return


### PR DESCRIPTION
#196 のための修正です
- #197 で入ったbugを修正しました
- escape/unescapeではなくencodeURI/decodeURIを使うようにした
