### PR TITLE
md5のみでrepimage DBに保存されている場合、全てhttp://gyazo.com/(hash).pngであると扱って表示する

### DIFF
--- a/controllers/api.coffee
+++ b/controllers/api.coffee
@@ -27,6 +27,8 @@ module.exports = (app) ->
           res.redirect image
         if /^[a-z0-9]+\.(jpe?g|gif|png)$/.test image
           res.redirect "/upload/#{image}"
+        else
+          res.redirect "//gyazo.com/#{image}.png"
       else
         res.status(404).send "image not found"
 

--- a/public/javascripts/gyazz_related.coffee
+++ b/public/javascripts/gyazz_related.coffee
@@ -10,10 +10,13 @@ class GyazzRelated
         pages.map (page) ->
           title = page.title
           repimage = page.repimage
-          imageurl = if repimage?.match(/^[0-9a-f]+\.(png|jpe?g|gif)$/)
-            "//#{location.host}/upload/#{repimage}"
-          else
-            repimage
+          imageurl =
+            if /^[0-9a-f]+\.(png|jpe?g|gif)$/.test repimage
+              "/upload/#{repimage}"
+            else if /^[0-9a-f]+$/.test repimage
+              "//gyazo.com/#{repimage}.png"
+            else
+              repimage
           url = "/#{wiki}/#{title}"
           if repimage
             iconCSS =


### PR DESCRIPTION
#200 を修正しました
