### PR TITLE
add dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ public/javascripts/*.js
 dump/gyazz
 .vagrant
 */upload/*
+.env

--- a/gyazz.coffee
+++ b/gyazz.coffee
@@ -10,11 +10,15 @@ license_key = process.env.NEW_RELIC_LICENSE_KEY or newRelicConfig.license_key
 if(app_name.length > 0 and license_key.length > 0)
   require('newrelic')
 
+dotenv   = require 'dotenv'
 express  = require 'express'
 favicon  = require 'serve-favicon'
 mongoose = require 'mongoose'
 path     = require 'path'
 debug    = require('debug')('gyazz:app')
+
+## load environments from '.env'
+dotenv.load()
 
 ## express modules
 bodyParser = require 'body-parser'

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "coffeelint": "*",
     "cookie-parser": "^1.0.1",
     "debug": "^0.7.4",
+    "dotenv": "^0.4.0",
     "express": "^4.4",
     "grunt": "*",
     "grunt-cli": "*",


### PR DESCRIPTION
主にheroku以外での運用向け

プロジェクトルートに`.env`を置いて、中に

```
GYAZZ_URL='http://localhost:3000'
```

などと書いておけば、起動時にprocess.envにassignされるようになります
