### PR TITLE
remove jQuery.param, use encodeURIComponent

### DIFF
--- a/public/javascripts/gyazz_edit.coffee
+++ b/public/javascripts/gyazz_edit.coffee
@@ -1,6 +1,4 @@
-query = $.param
-  wiki:  wiki
-  title: title
+query = "wiki=#{encodeURIComponent wiki}&title=#{encodeURIComponent title}"
 
 socket = io.connect "#{location.protocol}//#{location.hostname}?#{query}"
 gt = new GyazzTag

--- a/public/javascripts/gyazz_socket.coffee
+++ b/public/javascripts/gyazz_socket.coffee
@@ -1,9 +1,7 @@
 class GyazzSocket
 
   init: (gb, gd, gt) ->
-    query = $.param
-      wiki:  wiki
-      title: title
+    query = "wiki=#{encodeURIComponent wiki}&title=#{encodeURIComponent title}"
     @socket = io.connect "#{location.protocol}//#{location.hostname}?#{query}"
     @gb = gb
     @gd = gd

--- a/sockets/readwrite.coffee
+++ b/sockets/readwrite.coffee
@@ -16,8 +16,8 @@ module.exports = (app) ->
   io.on 'connection', (socket) ->
     debug "socket.io connected from client"
 
-    wiki  = decodeURI socket.handshake.query.wiki
-    title = decodeURI socket.handshake.query.title
+    wiki  = decodeURIComponent socket.handshake.query.wiki
+    title = decodeURIComponent socket.handshake.query.title
     unless wiki and title
       socket.disconnect()
       return


### PR DESCRIPTION
#213 の修正です

jQuery.paramを使うと、半角スペースが `%20` ではなく `+` に変換されるので廃止しました
encodeURIComponentを使うように戻しました
