### PR TITLE
add CORS header for /(wiki)/(pagename)/text API

### DIFF
--- a/controllers/api.coffee
+++ b/controllers/api.coffee
@@ -1,5 +1,6 @@
 debug = require('debug')('gyazz:controller:api')
 mongoose = require 'mongoose'
+cors     = require 'cors'
 _        = require 'underscore'
 async    = require 'async'
 PNG      = require '../lib/png'
@@ -44,7 +45,7 @@ module.exports = (app) ->
         data: list
 
   #  ページ内容取得 (apiとしてだけ)用意
-  app.get /^\/([^\/]+)\/(.*)\/(text|json)$/, (req, res) ->
+  app.get /^\/([^\/]+)\/(.*)\/(text|json)$/, cors(), (req, res) ->
     wiki  = req.params[0]
     title = req.params[1]
     ext   = req.params[2]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "coffee-script": "^1.7.1",
     "coffeelint": "*",
     "cookie-parser": "^1.0.1",
+    "cors": "^2.7.1",
     "debug": "*",
     "dotenv": "^1.2.0",
     "express": "^4.4",


### PR DESCRIPTION
#249 やりました
- /(wikiname)/(pagename)/text
- /(wikiname)/(pagename)/json

に `Access-Control-Allow-Origin: *` を付けました
